### PR TITLE
docs: correct scope note version to v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # gqlgen [![Continuous Integration](https://github.com/dgraph-io/gqlgen/workflows/Continuous%20Integration/badge.svg)](https://github.com/dgraph-io/gqlgen/actions) [![Read the Docs](https://badgen.net/badge/docs/available/green)](http://gqlgen.com/) [![GoDoc](https://godoc.org/github.com/dgraph-io/gqlgen?status.svg)](https://godoc.org/github.com/dgraph-io/gqlgen)
 
-> **Scope note (v0.14.0).** This fork carries only the runtime `graphql` packages that Dgraph imports:
+> **Scope note (v1.0.0).** This fork carries only the runtime `graphql` packages that Dgraph imports:
 > `graphql`, `graphql/errcode`, `graphql/introspection`, and `graphql/playground`. The codegen toolchain
 > (`api`, `client`, `cmd`, `codegen`, `complexity`, `plugin`), the examples, and the integration suite were
 > removed to shrink the transitive dependency surface. Sections below that describe codegen, `gqlgen init`,
 > and the examples no longer apply here; use [99designs/gqlgen](https://github.com/99designs/gqlgen) for
-> those. `v0.13.2` is the last release carrying the full toolchain.
+> those. `v0.13.2` is the last release carrying the full toolchain. The jump straight to `v1.0.0` leaves
+> upstream's version namespace on purpose: upstream occupies `v0.14.0` through `v0.17.x`, and this fork no
+> longer tracks it.
 
 ![gqlgen](https://user-images.githubusercontent.com/46195831/89802919-0bb8ef00-db2a-11ea-8ba4-88e7a58b2fd2.png)
 


### PR DESCRIPTION
One-line follow-up to #5, needed before the release tag goes out.

#5 landed a README scope note labelled `v0.14.0`. The release is going out as **v1.0.0** instead: upstream 99designs/gqlgen already occupies `v0.14.0` through `v0.17.x`, and this fork's tree no longer resembles upstream at any of those versions, so reusing one of its numbers would mislead anyone reading the version alone. Module paths differ, so there was never a proxy-level conflict, just a human one.

Also adds a sentence explaining the jump from `v0.13.2` straight to `v1.0.0`, so the gap doesn't look like an accident later.

v1 needs no `/v1` module path suffix, so `go.mod` is unchanged.

## Test plan

Documentation only, no code touched. `git diff --stat` is `README.md | 6 ++++--`.

Merging this unblocks tagging `v1.0.0` at the resulting master commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/gqlgen/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788019876&installation_model_id=8575&pr_number=6&repository=dgraph-io%2Fgqlgen&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fgqlgen%2Fpull%2F6&signature=5eff0e8e9d4471280a4904200a1b4d69375c375c8a28fd78bf34972096ce3946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->